### PR TITLE
log format error

### DIFF
--- a/src/report/report_client.cpp
+++ b/src/report/report_client.cpp
@@ -192,7 +192,14 @@ int main(int argc, char **argv) {
                                 if (strLine.empty()) {
                                     continue;
                                 }
-                                json j = json::parse(strLine);
+
+                                json j;
+                                try {
+                                    j = json::parse(strLine);
+                                }catch (...) {
+                                    remove(fileName.c_str());
+                                    continue;
+                                }
 
                                 UpstreamSegment request;
 


### PR DESCRIPTION
Exception caught when sky walk log format is invalid.