### PR TITLE
Fix the mistake of field entryOperationName in sw6 header.

### DIFF
--- a/skywalking.c
+++ b/skywalking.c
@@ -1281,7 +1281,26 @@ static void generate_context() {
             add_assoc_long(&SKYWALKING_G(context), "parentApplicationInstance", application_instance);
             add_assoc_long(&SKYWALKING_G(context), "entryApplicationInstance", application_instance);
             char *uri = get_page_request_uri();
-            add_assoc_string(&SKYWALKING_G(context), "entryOperationName", (uri == NULL) ? "" : uri);
+            char *path = NULL;
+            if (uri != NULL) {
+                path = (char *)emalloc(strlen(uri) + 5);
+                bzero(path, strlen(uri) + 5);
+
+                int i;
+                for(i = 0; i < strlen(uri); i++) {
+                    if (uri[i] == '?') {
+                        break;
+                    }
+                    path[i] = uri[i];
+                }
+                path[i] = '\0';
+            }
+
+            add_assoc_string(&SKYWALKING_G(context), "entryOperationName", (path == NULL) ? "" : path);
+            if (path != NULL) {
+                efree(path);
+            }
+
             add_assoc_string(&SKYWALKING_G(context), "distributedTraceId", makeTraceId);
             if(uri != NULL) {
                 efree(uri);


### PR DESCRIPTION
这个错误会导致当入口URL带get参数的时候，被接口调用的项目在链路上不能显示。
只修复了sw6，估计sw3也是需要的，但是没有测试过。

修复前：
![image](https://user-images.githubusercontent.com/8677974/74321582-78427380-4dbd-11ea-8a1e-8d478cd15891.png)

修复后：
![image](https://user-images.githubusercontent.com/8677974/74321639-96a86f00-4dbd-11ea-8633-f5871daf78a6.png)

端点分别是：
![image](https://user-images.githubusercontent.com/8677974/74321738-c5264a00-4dbd-11ea-95ad-115c7e92505d.png)

![image](https://user-images.githubusercontent.com/8677974/74321757-cd7e8500-4dbd-11ea-9c0d-f6d2954e789d.png)
