### PR TITLE
Fix CloseAndRecv detection.

### DIFF
--- a/agent/service/trace.go
+++ b/agent/service/trace.go
@@ -117,7 +117,7 @@ func (t *Agent) send(segments []*upstreamSegment) {
 	if streamV5 != nil {
 		streamV5.CloseAndRecv()
 	}
-	if streamV6 == nil {
+	if streamV6 != nil {
 		streamV6.CloseAndRecv()
 	}
 	log.Info("sending success...")


### PR DESCRIPTION
不及时CloseAndRecv有可能导致trace时偶尔会超时。