### PR TITLE
Fix SKY_IS_LARAVELS and multi php process message_queue problem.

### DIFF
--- a/php_skywalking.h
+++ b/php_skywalking.h
@@ -55,7 +55,7 @@ extern zend_module_entry skywalking_module_entry;
 #define SKY_IS_SWOOLE(func_name) (SKY_STRCMP(func_name, "{closure}"))
 #define SKY_IS_HYPERF(class_name, func_name) (SKY_STRCMP(class_name, "Hyperf\\HttpServer\\Server") && SKY_STRCMP(func_name, "onRequest"))
 #define SKY_IS_TARS(class_name, func_name) (SKY_STRCMP(class_name, "Tars\\core\\Server") && SKY_STRCMP(func_name, "onRequest"))
-#define SKY_IS_LARAVELS(class_name, func_name) (SKY_STRCMP(class_name, "Hhxsv\\LaravelS\\LaravelS") && SKY_STRCMP(func_name, "onRequest"))
+#define SKY_IS_LARAVELS(class_name, func_name) ((SKY_STRCMP(class_name, "Hhxsv\\LaravelS\\LaravelS") || SKY_STRCMP(class_name, "Hhxsv5\\LaravelS\\LaravelS")) && SKY_STRCMP(func_name, "onRequest"))
 #define SKY_IS_SWOOLE_FRAMEWORK(class_name, func_name) SKY_IS_HYPERF(class_name, func_name) || SKY_IS_TARS(class_name, func_name) || SKY_IS_LARAVELS(class_name, func_name)
 
 #if PHP_VERSION_ID < 80000

--- a/skywalking.cc
+++ b/skywalking.cc
@@ -161,6 +161,11 @@ PHP_MINIT_FUNCTION (skywalking) {
 
 PHP_MSHUTDOWN_FUNCTION (skywalking) {
     UNREGISTER_INI_ENTRIES();
+
+    if (SKYWALKING_G(enable)) {
+        sky_module_cleanup();
+    }
+
     return SUCCESS;
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -28,6 +28,7 @@
 struct service_info {
     char service[0x400];
     char service_instance[0x400];
+    char mq_name[32];
 
     boost::interprocess::message_queue *mq;
 };

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -155,7 +155,7 @@ void Manager::login(const ManagerOptions &options, struct service_info *info) {
         auto writer = stub->collect(&context, &commands);
 
         try {
-            boost::interprocess::message_queue mq(boost::interprocess::open_only, "skywalking_queue");
+            boost::interprocess::message_queue mq(boost::interprocess::open_only, s_info->mq_name);
 
             while (true) {
                 std::string data;

--- a/src/sky_module.h
+++ b/src/sky_module.h
@@ -22,6 +22,8 @@
 
 void sky_module_init();
 
+void sky_module_cleanup();
+
 void sky_request_init(zval *request, uint64_t request_id);
 
 void sky_request_flush(zval *response, uint64_t request_id);


### PR DESCRIPTION
修复两个问题：

1. LaravelS 的命名空间应该是 Hhxsv5吧（作者的名字），原来写成了Hhxsv，为了兼容，我增加了个判断。
2. LaravelS启动时有个runArtisanCommand的动作，会用popen开新的php进程调用artisan config这个动作，导致sky_module_init调用了两次，boost::interprocess::message_queue::remove也被调用了两次，message_queue不正常了，我把名字改成了skywalking_queue_[pid]这样子以防止这种情况，你看看可不可行。