### PR TITLE
Rate limitor, fix mem leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ e2e/composer.lock
 e2e/vendor
 vendor
 composer.*
+/.vscode

--- a/config.m4
+++ b/config.m4
@@ -181,6 +181,7 @@ if test "$PHP_SKYWALKING" != "no"; then
       src/sky_plugin_rabbit_mq.cc \
       src/sky_plugin_redis.cc \
       src/sky_plugin_swoole_curl.cc \
+      src/sky_rate_limit.cc \
       src/sky_shm.cc \
       src/sky_utils.cc \
       src/span.cc \

--- a/php.ini
+++ b/php.ini
@@ -28,3 +28,5 @@ skywalking.enable = 1
 skywalking.version = 8
 skywalking.grpc = 127.0.0.1:11800
 skywalking.error_handler_enable = 0
+skywalking.sample_n_per_3_secs = -1
+skywalking.instance_name = ""

--- a/php_skywalking.h
+++ b/php_skywalking.h
@@ -140,6 +140,7 @@ ZEND_BEGIN_MODULE_GLOBALS(skywalking)
     int mq_max_message_length;
 
     // rate limit
+    void *rate_limitor;
     int rate_limit;
     int time_window; // seconds
 

--- a/php_skywalking.h
+++ b/php_skywalking.h
@@ -144,7 +144,7 @@ ZEND_BEGIN_MODULE_GLOBALS(skywalking)
     int rate_limit;
     int time_window; // seconds
 
-    // fixed UUID
+    // fixed UUID path
     char *uuid_path;
 ZEND_END_MODULE_GLOBALS(skywalking)
 

--- a/php_skywalking.h
+++ b/php_skywalking.h
@@ -138,6 +138,13 @@ ZEND_BEGIN_MODULE_GLOBALS(skywalking)
 
     // message queue
     int mq_max_message_length;
+
+    // rate limit
+    int rate_limit;
+    int time_window; // seconds
+
+    // fixed UUID
+    char *uuid_path;
 ZEND_END_MODULE_GLOBALS(skywalking)
 
 extern ZEND_DECLARE_MODULE_GLOBALS(skywalking);

--- a/php_skywalking.h
+++ b/php_skywalking.h
@@ -141,11 +141,10 @@ ZEND_BEGIN_MODULE_GLOBALS(skywalking)
 
     // rate limit
     void *rate_limitor;
-    int rate_limit;
-    int time_window; // seconds
+    int sample_n_per_3_secs;
 
-    // fixed UUID path
-    char *uuid_path;
+    // fixed UUID
+    char *instance_name;
 ZEND_END_MODULE_GLOBALS(skywalking)
 
 extern ZEND_DECLARE_MODULE_GLOBALS(skywalking);

--- a/php_skywalking.h
+++ b/php_skywalking.h
@@ -145,7 +145,7 @@ ZEND_BEGIN_MODULE_GLOBALS(skywalking)
     int mq_max_message_length;
 
     // rate limit
-    void *rate_limitor;
+    void *rate_limiter;
     int sample_n_per_3_secs;
 
     // fixed UUID

--- a/skywalking.cc
+++ b/skywalking.cc
@@ -66,6 +66,11 @@ PHP_INI_BEGIN()
 
     STD_PHP_INI_ENTRY("skywalking.mq_max_message_length", "20480", PHP_INI_ALL, OnUpdateLong, mq_max_message_length, zend_skywalking_globals, skywalking_globals)
 
+    STD_PHP_INI_ENTRY("skywalking.rate", "0", PHP_INI_ALL, OnUpdateLong, rate, zend_skywalking_globals, skywalking_globals)
+    STD_PHP_INI_ENTRY("skywalking.time_window", "1", PHP_INI_ALL, OnUpdateLong, time_window, zend_skywalking_globals, skywalking_globals)
+
+    STD_PHP_INI_ENTRY("skywalking.uuid_path", "", PHP_INI_ALL, OnUpdateString, uuid_path, zend_skywalking_globals, skywalking_globals)
+
 PHP_INI_END()
 
 static void php_skywalking_init_globals(zend_skywalking_globals *skywalking_globals) {

--- a/skywalking.cc
+++ b/skywalking.cc
@@ -66,10 +66,9 @@ PHP_INI_BEGIN()
 
     STD_PHP_INI_ENTRY("skywalking.mq_max_message_length", "20480", PHP_INI_ALL, OnUpdateLong, mq_max_message_length, zend_skywalking_globals, skywalking_globals)
 
-    STD_PHP_INI_ENTRY("skywalking.rate_limit", "0", PHP_INI_ALL, OnUpdateLong, rate_limit, zend_skywalking_globals, skywalking_globals)
-    STD_PHP_INI_ENTRY("skywalking.time_window", "1", PHP_INI_ALL, OnUpdateLong, time_window, zend_skywalking_globals, skywalking_globals)
+    STD_PHP_INI_ENTRY("skywalking.sample_n_per_3_secs", "-1", PHP_INI_ALL, OnUpdateLong, sample_n_per_3_secs, zend_skywalking_globals, skywalking_globals)
 
-    STD_PHP_INI_ENTRY("skywalking.uuid_path", "", PHP_INI_ALL, OnUpdateString, uuid_path, zend_skywalking_globals, skywalking_globals)
+    STD_PHP_INI_ENTRY("skywalking.instance_name", "", PHP_INI_ALL, OnUpdateString, instance_name, zend_skywalking_globals, skywalking_globals)
 
 PHP_INI_END()
 
@@ -97,11 +96,10 @@ static void php_skywalking_init_globals(zend_skywalking_globals *skywalking_glob
     skywalking_globals->mq_max_message_length = 0;
 
     // rate limit
-    skywalking_globals->rate_limit = 0;
-    skywalking_globals->time_window = 1;
+    skywalking_globals->sample_n_per_3_secs = -1;
 
     // uuid path
-    skywalking_globals->uuid_path = nullptr;
+    skywalking_globals->instance_name = nullptr;
 
 }
 

--- a/skywalking.cc
+++ b/skywalking.cc
@@ -66,7 +66,7 @@ PHP_INI_BEGIN()
 
     STD_PHP_INI_ENTRY("skywalking.mq_max_message_length", "20480", PHP_INI_ALL, OnUpdateLong, mq_max_message_length, zend_skywalking_globals, skywalking_globals)
 
-    STD_PHP_INI_ENTRY("skywalking.rate", "0", PHP_INI_ALL, OnUpdateLong, rate, zend_skywalking_globals, skywalking_globals)
+    STD_PHP_INI_ENTRY("skywalking.rate_limit", "0", PHP_INI_ALL, OnUpdateLong, rate_limit, zend_skywalking_globals, skywalking_globals)
     STD_PHP_INI_ENTRY("skywalking.time_window", "1", PHP_INI_ALL, OnUpdateLong, time_window, zend_skywalking_globals, skywalking_globals)
 
     STD_PHP_INI_ENTRY("skywalking.uuid_path", "", PHP_INI_ALL, OnUpdateString, uuid_path, zend_skywalking_globals, skywalking_globals)

--- a/skywalking.cc
+++ b/skywalking.cc
@@ -95,6 +95,14 @@ static void php_skywalking_init_globals(zend_skywalking_globals *skywalking_glob
 
     // message queue
     skywalking_globals->mq_max_message_length = 0;
+
+    // rate limit
+    skywalking_globals->rate_limit = 0;
+    skywalking_globals->time_window = 1;
+
+    // uuid path
+    skywalking_globals->uuid_path = nullptr;
+
 }
 
 PHP_FUNCTION (skywalking_trace_id) {

--- a/src/cross_process_bag.cc
+++ b/src/cross_process_bag.cc
@@ -88,15 +88,15 @@ std::string CrossProcessBag::encode(int spanId, const std::string &peer) {
     return header;
 }
 
-void CrossProcessBag::setOperationName(std::string name) {
-    currentOperationName = std::move(name);
+void CrossProcessBag::setOperationName(const std::string &name) {
+    currentOperationName = name;
 }
 
-std::string CrossProcessBag::getTraceId() {
+const std::string &CrossProcessBag::getTraceId() {
     return traceId;
 }
 
-std::string CrossProcessBag::getParentTraceSegmentId() {
+const std::string &CrossProcessBag::getParentTraceSegmentId() {
     return parentSegmentId;
 }
 
@@ -104,18 +104,18 @@ int CrossProcessBag::getParentSpanId() const {
     return parentSpanId;
 }
 
-std::string CrossProcessBag::getParentService() {
+const std::string &CrossProcessBag::getParentService() {
     return parentService;
 }
 
-std::string CrossProcessBag::getParentServiceInstance() {
+const std::string &CrossProcessBag::getParentServiceInstance() {
     return parentServiceInstance;
 }
 
-std::string CrossProcessBag::getParentEndpoint() {
+const std::string &CrossProcessBag::getParentEndpoint() {
     return parentEndpoint;
 }
 
-std::string CrossProcessBag::getNetworkAddressUsedAtPeer() {
+const std::string &CrossProcessBag::getNetworkAddressUsedAtPeer() {
     return networkAddressUsedAtPeer;
 }

--- a/src/cross_process_bag.h
+++ b/src/cross_process_bag.h
@@ -33,21 +33,21 @@ public:
 
     std::string encode(int spanId, const std::string &peer);
 
-    void setOperationName(std::string name);
+    void setOperationName(const std::string &name);
 
-    std::string getTraceId();
+    const std::string &getTraceId();
 
-    std::string getParentTraceSegmentId();
+    const std::string &getParentTraceSegmentId();
 
     int getParentSpanId() const;
 
-    std::string getParentService();
+    const std::string &getParentService();
 
-    std::string getParentServiceInstance();
+    const std::string &getParentServiceInstance();
 
-    std::string getParentEndpoint();
+    const std::string &getParentEndpoint();
 
-    std::string getNetworkAddressUsedAtPeer();
+    const std::string &getNetworkAddressUsedAtPeer();
 
 private:
     void decode(const std::string &h);

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -48,17 +48,12 @@ static pthread_mutex_t cond_mx = PTHREAD_MUTEX_INITIALIZER;
 
 extern struct service_info *s_info;
 
-Manager::Manager(const ManagerOptions &options, struct service_info *info) {
-
-
+void Manager::init(const ManagerOptions &options, struct service_info *info) {
     std::thread th(login, options, info);
     th.detach();
 
     std::thread c(consumer, options);
     c.detach();
-
-//    std::thread s(sender, options);
-//    s.detach();
 
     sky_log("the apache skywalking php plugin mounted");
 }

--- a/src/manager.cc
+++ b/src/manager.cc
@@ -51,15 +51,8 @@ extern struct service_info *s_info;
 static std::string fixed_uuid;
 
 void Manager::init(const ManagerOptions &options, struct service_info *info) {
-    if (!options.uuid_path.empty()) {
-        try {
-            std::ifstream uuid_stream(options.uuid_path, std::ios::in);
-            uuid_stream.exceptions(std::ifstream::badbit);
-            uuid_stream >> fixed_uuid;
-        } catch (...) {
-            sky_log("read from uuid_path failed");
-            fixed_uuid.clear();
-        }
+    if (!options.instance_name.empty()) {
+        fixed_uuid = options.instance_name;
     }
 
     std::thread th(login, options, info);

--- a/src/manager.h
+++ b/src/manager.h
@@ -46,6 +46,7 @@ struct ManagerOptions {
     std::string private_key;
     std::string cert_chain;
     std::string authentication;
+    std::string uuid_path;
 };
 
 class Manager {

--- a/src/manager.h
+++ b/src/manager.h
@@ -51,11 +51,12 @@ struct ManagerOptions {
 class Manager {
 
 public:
-    Manager(const ManagerOptions &options, struct service_info *info);
-
     static std::string generateUUID();
 
+    static void init(const ManagerOptions &options, struct service_info *info);
+
 private:
+    Manager() = delete;
 
     static void login(const ManagerOptions &options, struct service_info *info);
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -46,7 +46,7 @@ struct ManagerOptions {
     std::string private_key;
     std::string cert_chain;
     std::string authentication;
-    std::string uuid_path;
+    std::string instance_name;
 };
 
 class Manager {

--- a/src/segment.cc
+++ b/src/segment.cc
@@ -49,6 +49,9 @@ Segment::Segment(const std::string &serviceId, const std::string &serviceInstanc
 
 Segment::~Segment() {
     delete bag;
+    for (Span *span : spans) {
+        delete span;
+    }
     spans.clear();
     spans.shrink_to_fit();
 }

--- a/src/segment.cc
+++ b/src/segment.cc
@@ -185,6 +185,6 @@ void Segment::createRefs() {
     }
 }
 
-const std::string &Segment::getTraceId() {
+const std::string& Segment::getTraceId() {
     return _traceId;
 }

--- a/src/segment.cc
+++ b/src/segment.cc
@@ -185,6 +185,6 @@ void Segment::createRefs() {
     }
 }
 
-std::string Segment::getTraceId() {
+const std::string &Segment::getTraceId() {
     return _traceId;
 }

--- a/src/segment.cc
+++ b/src/segment.cc
@@ -189,3 +189,11 @@ void Segment::createRefs() {
 const std::string& Segment::getTraceId() {
     return _traceId;
 }
+
+void Segment::setSkip(bool skip) {
+    this->doSkip = skip;
+}
+
+bool Segment::skip() {
+    return doSkip;
+}

--- a/src/segment.h
+++ b/src/segment.h
@@ -48,6 +48,10 @@ public:
 
     const std::string& getTraceId();
 
+    void setSkip(bool skip);
+
+    bool skip();
+
     ~Segment();
 
 private:
@@ -61,6 +65,7 @@ private:
     std::string _serviceId;
     std::string _serviceInstanceId;
     bool isSizeLimited = false;
+    bool doSkip = false;
 
     int _status_code = 200;
 };

--- a/src/segment.h
+++ b/src/segment.h
@@ -46,7 +46,7 @@ public:
 
     void createRefs();
 
-    std::string getTraceId();
+    const std::string &getTraceId();
 
     ~Segment();
 

--- a/src/segment.h
+++ b/src/segment.h
@@ -46,7 +46,7 @@ public:
 
     void createRefs();
 
-    const std::string &getTraceId();
+    const std::string& getTraceId();
 
     ~Segment();
 

--- a/src/sky_core_span_log.cc
+++ b/src/sky_core_span_log.cc
@@ -20,7 +20,6 @@
 
 #include <utility>
 #include <string>
-#include <map>
 #include <sky_utils.h>
 
 SkyCoreSpanLog::SkyCoreSpanLog(std::string key, std::string value) : _key(std::move(key)), _value(std::move(value)) {

--- a/src/sky_core_span_log.cc
+++ b/src/sky_core_span_log.cc
@@ -31,10 +31,10 @@ long SkyCoreSpanLog::getTime() {
     return _time;
 }
 
-std::string SkyCoreSpanLog::getKey() {
+const std::string &SkyCoreSpanLog::getKey() {
     return _key;
 }
 
-std::string SkyCoreSpanLog::getValue() {
+const std::string &SkyCoreSpanLog::getValue() {
     return _value;
 }

--- a/src/sky_core_span_log.h
+++ b/src/sky_core_span_log.h
@@ -29,9 +29,9 @@ public:
 
     long getTime();
 
-    std::string getKey();
+    const std::string &getKey();
 
-    std::string getValue();
+    const std::string &getValue();
 
 private:
     long _time;

--- a/src/sky_core_span_log.h
+++ b/src/sky_core_span_log.h
@@ -21,7 +21,6 @@
 
 #include <string>
 #include <vector>
-#include <map>
 
 class SkyCoreSpanLog {
 public:

--- a/src/sky_execute.cc
+++ b/src/sky_execute.cc
@@ -148,7 +148,7 @@ void sky_execute_internal(zend_execute_data *execute_data, zval *return_value) {
             uint32_t arg_count = ZEND_CALL_NUM_ARGS(execute_data);
             if (arg_count >= 1) {
                 zval *status = ZEND_CALL_ARG(execute_data, 1);
-                if (Z_TYPE_P(status) == IS_LONG) {
+                if (Z_TYPE_P(status) == IS_LONG && segment != nullptr) {
                     segment->setStatusCode(Z_LVAL_P(status));
                 }
             }

--- a/src/sky_grpc.cc
+++ b/src/sky_grpc.cc
@@ -31,6 +31,10 @@ Span *sky_grpc(zend_execute_data *execute_data, char *class_name, char *function
         _function_name == "_serverStreamRequest" || _function_name == "_bidiRequest") {
 
         auto *segment = sky_get_segment(execute_data, -1);
+        if (segment == nullptr) {
+            return nullptr;
+        }
+
         auto *span = segment->createSpan(SkySpanType::Exit, SkySpanLayer::RPCFramework, 23);
         span->setOperationName(_class_name + "->" + _function_name);
         span->addTag("rpc.type", "grpc");

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -78,8 +78,8 @@ void sky_module_init() {
     std::unordered_map<uint64_t, Segment *> *segments = new std::unordered_map<uint64_t, Segment *>;
     SKYWALKING_G(segment) = segments;
 
-    FixedWindowRateLimitor *rate_limitor = new FixedWindowRateLimitor(SKYWALKING_G(sample_n_per_3_secs));
-    SKYWALKING_G(rate_limitor) = rate_limitor;
+    FixedWindowRateLimiter *rate_limiter = new FixedWindowRateLimiter(SKYWALKING_G(sample_n_per_3_secs));
+    SKYWALKING_G(rate_limiter) = rate_limiter;
 
     sprintf(s_info->mq_name, "skywalking_queue_%d", getpid());
 
@@ -123,14 +123,14 @@ void sky_module_cleanup() {
     }
 
     delete segments;
-    delete static_cast<FixedWindowRateLimitor*>(SKYWALKING_G(rate_limitor));
+    delete static_cast<FixedWindowRateLimiter*>(SKYWALKING_G(rate_limiter));
 }
 
 void sky_request_init(zval *request, uint64_t request_id) {
     array_init(&SKYWALKING_G(curl_header));
 
-    if (!static_cast<FixedWindowRateLimitor*>(SKYWALKING_G(rate_limitor))->validate()) {
-        auto *segment = new Segment(s_info->service, s_info->service_instance, SKYWALKING_G(version), header);
+    if (!static_cast<FixedWindowRateLimiter*>(SKYWALKING_G(rate_limiter))->validate()) {
+        auto *segment = new Segment(s_info->service, s_info->service_instance, SKYWALKING_G(version), "");
         segment->setSkip(true);
         (void)sky_insert_segment(request_id, segment);
 

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -123,7 +123,7 @@ void sky_module_cleanup() {
     }
 
     delete segments;
-    delete rate_limitor;
+    delete static_cast<FixedWindowRateLimitor*>(SKYWALKING_G(rate_limitor));
 }
 
 void sky_request_init(zval *request, uint64_t request_id) {

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -84,9 +84,7 @@ void sky_module_init() {
     opt.private_key = SKYWALKING_G(grpc_tls_pem_private_key);
     opt.cert_chain = SKYWALKING_G(grpc_tls_pem_cert_chain);
     opt.authentication = SKYWALKING_G(authentication);
-    if (SKYWALKING_G(uuid_path) != nullptr) {
-        opt.uuid_path = SKYWALKING_G(uuid_path);
-    }
+    opt.uuid_path = SKYWALKING_G(uuid_path);
 
     std::unordered_map<uint64_t, Segment *> *segments = new std::unordered_map<uint64_t, Segment *>;
     SKYWALKING_G(segment) = segments;

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -45,7 +45,7 @@ extern void (*orig_curl_setopt_array)(INTERNAL_FUNCTION_PARAMETERS);
 
 extern void (*orig_curl_close)(INTERNAL_FUNCTION_PARAMETERS);
 
-static FixedWindowRateLimitor *rate_limitor = nullptr;
+FixedWindowRateLimitor *rate_limitor = nullptr;
 
 void sky_module_init() {
     ori_execute_ex = zend_execute_ex;

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -127,11 +127,11 @@ void sky_module_cleanup() {
 }
 
 void sky_request_init(zval *request, uint64_t request_id) {
+    array_init(&SKYWALKING_G(curl_header));
+
     if (!static_cast<FixedWindowRateLimitor*>(SKYWALKING_G(rate_limitor))->validate()) {
         return;
     }
-
-    array_init(&SKYWALKING_G(curl_header));
 
     zval *carrier = nullptr;
     zval *sw, *peer_val;

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -91,7 +91,7 @@ void sky_module_init() {
     std::unordered_map<uint64_t, Segment *> *segments = new std::unordered_map<uint64_t, Segment *>;
     SKYWALKING_G(segment) = segments;
 
-    rate_limitor = new FixedWindowRateLimitor(SKYWALKING_G(rate), SKYWALKING_G(time_window));
+    rate_limitor = new FixedWindowRateLimitor(SKYWALKING_G(rate_limit), SKYWALKING_G(time_window));
 
     sprintf(s_info->mq_name, "skywalking_queue_%d", getpid());
 

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -75,21 +75,10 @@ void sky_module_init() {
         old_function->internal_function.handler = sky_curl_close_handler;
     }
 
-    ManagerOptions opt;
-    opt.version = SKYWALKING_G(version);
-    opt.code = SKYWALKING_G(app_code);
-    opt.grpc = SKYWALKING_G(grpc);
-    opt.grpc_tls = SKYWALKING_G(grpc_tls_enable);
-    opt.root_certs = SKYWALKING_G(grpc_tls_pem_root_certs);
-    opt.private_key = SKYWALKING_G(grpc_tls_pem_private_key);
-    opt.cert_chain = SKYWALKING_G(grpc_tls_pem_cert_chain);
-    opt.authentication = SKYWALKING_G(authentication);
-    opt.uuid_path = SKYWALKING_G(uuid_path);
-
     std::unordered_map<uint64_t, Segment *> *segments = new std::unordered_map<uint64_t, Segment *>;
     SKYWALKING_G(segment) = segments;
 
-    FixedWindowRateLimitor *rate_limitor = new FixedWindowRateLimitor(SKYWALKING_G(rate_limit), SKYWALKING_G(time_window));
+    FixedWindowRateLimitor *rate_limitor = new FixedWindowRateLimitor(SKYWALKING_G(sample_n_per_3_secs));
     SKYWALKING_G(rate_limitor) = rate_limitor;
 
     sprintf(s_info->mq_name, "skywalking_queue_%d", getpid());
@@ -106,6 +95,17 @@ void sky_module_init() {
     } catch (boost::interprocess::interprocess_exception &ex) {
         php_error(E_WARNING, "%s %s", "[skywalking] create queue fail ", ex.what());
     }
+
+    ManagerOptions opt;
+    opt.version = SKYWALKING_G(version);
+    opt.code = SKYWALKING_G(app_code);
+    opt.grpc = SKYWALKING_G(grpc);
+    opt.grpc_tls = SKYWALKING_G(grpc_tls_enable);
+    opt.root_certs = SKYWALKING_G(grpc_tls_pem_root_certs);
+    opt.private_key = SKYWALKING_G(grpc_tls_pem_private_key);
+    opt.cert_chain = SKYWALKING_G(grpc_tls_pem_cert_chain);
+    opt.authentication = SKYWALKING_G(authentication);
+    opt.instance_name = SKYWALKING_G(instance_name);
 
     Manager::init(opt, s_info);
 }

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -84,7 +84,9 @@ void sky_module_init() {
     opt.private_key = SKYWALKING_G(grpc_tls_pem_private_key);
     opt.cert_chain = SKYWALKING_G(grpc_tls_pem_cert_chain);
     opt.authentication = SKYWALKING_G(authentication);
-    opt.uuid_path = SKYWALKING_G(uuid_path);
+    if (SKYWALKING_G(uuid_path) != nullptr) {
+        opt.uuid_path = SKYWALKING_G(uuid_path);
+    }
 
     std::unordered_map<uint64_t, Segment *> *segments = new std::unordered_map<uint64_t, Segment *>;
     SKYWALKING_G(segment) = segments;

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -99,7 +99,7 @@ void sky_module_init() {
         php_error(E_WARNING, "%s %s", "[skywalking] create queue fail ", ex.what());
     }
 
-    new Manager(opt, s_info);
+    Manager::init(opt, s_info);
 }
 
 void sky_module_cleanup() {

--- a/src/sky_pdo.cc
+++ b/src/sky_pdo.cc
@@ -31,7 +31,7 @@ Span *sky_pdo(zend_execute_data *execute_data, const std::string &class_name, co
             function_name == "prepare" || function_name == "commit" ||
             function_name == "begintransaction" || function_name == "rollback") {
             auto *segment = sky_get_segment(execute_data, -1);
-            if (segment == nullptr) {
+            if (segment->skip()) {
                 return nullptr;
             }
 
@@ -54,7 +54,7 @@ Span *sky_pdo(zend_execute_data *execute_data, const std::string &class_name, co
     } else {
         if (function_name == "execute") {
             auto *segment = sky_get_segment(execute_data, -1);
-            if (segment == nullptr) {
+            if (segment->skip()) {
                 return nullptr;
             }
 

--- a/src/sky_pdo.cc
+++ b/src/sky_pdo.cc
@@ -31,6 +31,10 @@ Span *sky_pdo(zend_execute_data *execute_data, const std::string &class_name, co
             function_name == "prepare" || function_name == "commit" ||
             function_name == "begintransaction" || function_name == "rollback") {
             auto *segment = sky_get_segment(execute_data, -1);
+            if (segment == nullptr) {
+                return nullptr;
+            }
+
             auto *span = segment->createSpan(SkySpanType::Exit, SkySpanLayer::Database, 8003);
             span->setOperationName(class_name + "->" + function_name);
 
@@ -50,6 +54,10 @@ Span *sky_pdo(zend_execute_data *execute_data, const std::string &class_name, co
     } else {
         if (function_name == "execute") {
             auto *segment = sky_get_segment(execute_data, -1);
+            if (segment == nullptr) {
+                return nullptr;
+            }
+
             auto *span = segment->createSpan(SkySpanType::Exit, SkySpanLayer::Database, 8003);
             span->setOperationName(class_name + "->" + function_name);
 

--- a/src/sky_plugin_curl.cc
+++ b/src/sky_plugin_curl.cc
@@ -34,7 +34,7 @@ void (*orig_curl_close)(INTERNAL_FUNCTION_PARAMETERS) = nullptr;
 void sky_curl_setopt_handler(INTERNAL_FUNCTION_PARAMETERS) {
 
     auto *segment = sky_get_segment(execute_data, -1);
-    if (segment == nullptr) {
+    if (segment == nullptr || segment->skip()) {
         orig_curl_setopt(INTERNAL_FUNCTION_PARAM_PASSTHRU);
         return;
     }
@@ -70,7 +70,7 @@ void sky_curl_setopt_handler(INTERNAL_FUNCTION_PARAMETERS) {
 void sky_curl_setopt_array_handler(INTERNAL_FUNCTION_PARAMETERS) {
 
     auto *segment = sky_get_segment(execute_data, -1);
-    if (segment == nullptr) {
+    if (segment == nullptr || segment->skip()) {
         orig_curl_setopt_array(INTERNAL_FUNCTION_PARAM_PASSTHRU);
         return;
     }
@@ -103,7 +103,7 @@ void sky_curl_setopt_array_handler(INTERNAL_FUNCTION_PARAMETERS) {
 
 void sky_curl_exec_handler(INTERNAL_FUNCTION_PARAMETERS) {
     auto *segment = sky_get_segment(execute_data, -1);
-    if (segment == nullptr) {
+    if (segment == nullptr || segment->skip()) {
         orig_curl_exec(INTERNAL_FUNCTION_PARAM_PASSTHRU);
         return;
     }
@@ -254,7 +254,7 @@ void sky_curl_exec_handler(INTERNAL_FUNCTION_PARAMETERS) {
 void sky_curl_close_handler(INTERNAL_FUNCTION_PARAMETERS) {
 
     auto *segment = sky_get_segment(execute_data, -1);
-    if (segment == nullptr) {
+    if (segment == nullptr || segment->skip()) {
         orig_curl_close(INTERNAL_FUNCTION_PARAM_PASSTHRU);
         return;
     }

--- a/src/sky_plugin_grpc.cc
+++ b/src/sky_plugin_grpc.cc
@@ -33,7 +33,7 @@ Span *sky_plugin_grpc(zend_execute_data *execute_data, char *class_name, char *f
         _function_name == "_serverStreamRequest" || _function_name == "_bidiRequest") {
 
         auto *segment = sky_get_segment(execute_data, -1);
-        if (segment == nullptr) {
+        if (segment->skip()) {
             return nullptr;
         }
 

--- a/src/sky_plugin_hyperf_guzzle.cc
+++ b/src/sky_plugin_hyperf_guzzle.cc
@@ -26,7 +26,7 @@ extern void (*ori_execute_ex)(zend_execute_data *execute_data);
 Span *sky_plugin_hyperf_guzzle(zend_execute_data *execute_data, const std::string &class_name, const std::string &function_name) {
 
     auto *segment = sky_get_segment(execute_data, -1);
-    if (segment == nullptr) {
+    if (segment->skip()) {
         return nullptr;
     }
 

--- a/src/sky_plugin_hyperf_guzzle.cc
+++ b/src/sky_plugin_hyperf_guzzle.cc
@@ -26,6 +26,10 @@ extern void (*ori_execute_ex)(zend_execute_data *execute_data);
 Span *sky_plugin_hyperf_guzzle(zend_execute_data *execute_data, const std::string &class_name, const std::string &function_name) {
 
     auto *segment = sky_get_segment(execute_data, -1);
+    if (segment == nullptr) {
+        return nullptr;
+    }
+
     auto *span = segment->createSpan(SkySpanType::Exit, SkySpanLayer::Http, 8002);
 
     uint32_t arg_count = ZEND_CALL_NUM_ARGS(execute_data);

--- a/src/sky_plugin_mysqli.cc
+++ b/src/sky_plugin_mysqli.cc
@@ -49,7 +49,7 @@ Span *sky_plugin_mysqli(zend_execute_data *execute_data, const std::string &clas
     bool is_mysqli_func = function_name == "mysqli_query" || function_name == "mysqli_autocommit" || function_name == "mysqli_commit" || function_name == "mysqli_rollback";
     if (is_pdo_func || is_mysqli_func) {
         auto *segment = sky_get_segment(execute_data, -1);
-        if (segment == nullptr) {
+        if (segment->skip()) {
             return nullptr;
         }
 

--- a/src/sky_plugin_mysqli.cc
+++ b/src/sky_plugin_mysqli.cc
@@ -45,6 +45,10 @@ Span *sky_plugin_mysqli(zend_execute_data *execute_data, const std::string &clas
     if (function_name == "query" || function_name == "autocommit" || function_name == "commit" || function_name == "rollback" ||
         function_name == "mysqli_query" || function_name == "mysqli_autocommit" || function_name == "mysqli_commit" || function_name == "mysqli_rollback") {
             auto *segment = sky_get_segment(execute_data, -1);
+            if (segment == nullptr) {
+                return nullptr;
+            }
+
             auto *span = segment->createSpan(SkySpanType::Exit, SkySpanLayer::Database, 8004);
             uint32_t arg_count = ZEND_CALL_NUM_ARGS(execute_data);
 

--- a/src/sky_plugin_predis.cc
+++ b/src/sky_plugin_predis.cc
@@ -31,7 +31,7 @@ Span *sky_predis(zend_execute_data *execute_data, const std::string &class_name,
     uint32_t args = ZEND_CALL_NUM_ARGS(execute_data);
     if (args) {
         auto *segment = sky_get_segment(execute_data, -1);
-        if (segment == nullptr) {
+        if (segment->skip()) {
             return nullptr;
         }
         auto *span = segment->createSpan(SkySpanType::Exit, SkySpanLayer::Cache, 8006);

--- a/src/sky_plugin_rabbit_mq.cc
+++ b/src/sky_plugin_rabbit_mq.cc
@@ -24,7 +24,7 @@ Span *sky_plugin_rabbit_mq(zend_execute_data *execute_data, const std::string &c
 
     if (function_name == "basic_publish") {
         auto *segment = sky_get_segment(execute_data, -1);
-        if (segment == nullptr) {
+        if (segment->skip()) {
             return nullptr;
         }
         auto *span = segment->createSpan(SkySpanType::Exit, SkySpanLayer::MQ, 52);

--- a/src/sky_plugin_redis.cc
+++ b/src/sky_plugin_redis.cc
@@ -20,10 +20,10 @@
 
 std::unordered_map<std::string, redis_cmd_cb> commands = {
         // connection
-        /*{"SELECT",      sky_plugin_redis_select_cmd},
+        {"SELECT",      sky_plugin_redis_select_cmd},
         {"ECHO",        sky_plugin_redis_key_cmd},
         {"PING",        sky_plugin_redis_pure_cmd},
-        {"PIPELINE",    sky_plugin_redis_pure_cmd},//*/
+        {"PIPELINE",    sky_plugin_redis_pure_cmd},
 
         // server
         // @todo

--- a/src/sky_plugin_redis.cc
+++ b/src/sky_plugin_redis.cc
@@ -20,10 +20,10 @@
 
 std::unordered_map<std::string, redis_cmd_cb> commands = {
         // connection
-        {"SELECT",      sky_plugin_redis_select_cmd},
+        /*{"SELECT",      sky_plugin_redis_select_cmd},
         {"ECHO",        sky_plugin_redis_key_cmd},
         {"PING",        sky_plugin_redis_pure_cmd},
-        {"PIPELINE",    sky_plugin_redis_pure_cmd},
+        {"PIPELINE",    sky_plugin_redis_pure_cmd},//*/
 
         // server
         // @todo

--- a/src/sky_plugin_redis.cc
+++ b/src/sky_plugin_redis.cc
@@ -18,7 +18,7 @@
 
 #include "sky_plugin_redis.h"
 
-std::map<std::string, redis_cmd_cb> commands = {
+std::unordered_map<std::string, redis_cmd_cb> commands = {
         // connection
         {"SELECT",      sky_plugin_redis_select_cmd},
         {"ECHO",        sky_plugin_redis_key_cmd},
@@ -237,7 +237,7 @@ Span *sky_plugin_redis(zend_execute_data *execute_data, const std::string &class
     std::transform(function_name.begin(), function_name.end(), cmd.begin(), ::toupper);
     if (commands.count(cmd) > 0) {
         auto *segment = sky_get_segment(execute_data, -1);
-        if (segment) {
+        if (segment != nullptr) {
             auto *span = segment->createSpan(SkySpanType::Exit, SkySpanLayer::Cache, 7);
             span->setOperationName(class_name + "->" + function_name);
             span->addTag("db.type", "redis");

--- a/src/sky_plugin_redis.h
+++ b/src/sky_plugin_redis.h
@@ -23,7 +23,7 @@
 #include "sky_utils.h"
 #include <string>
 #include <functional>
-#include <map>
+#include <unordered_map>
 #include "span.h"
 #include "segment.h"
 

--- a/src/sky_plugin_swoole_curl.cc
+++ b/src/sky_plugin_swoole_curl.cc
@@ -60,7 +60,7 @@ void sky_plugin_swoole_curl(zend_execute_data *execute_data, const std::string &
 
             if (_scheme == "http" || _scheme == "https") {
                 auto *segment = sky_get_segment(execute_data, -1);
-                if (segment) {
+                if (segment != nullptr) {
                     span = segment->createSpan(SkySpanType::Exit, SkySpanLayer::Http, 8002);
                     span->setPeer(_host + ":" + std::to_string(_port));
                     span->setOperationName(_path);

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -1,0 +1,36 @@
+#include <cmath>
+#include "sky_rate_limit.h"
+
+FixedWindowRateLimitor::FixedWindowRateLimitor(int64_t rate, int seconds) : rate(rate), currentCount(0), resetLock(false) {
+    if (seconds < 1) {
+        timeWindow = std::chrono::seconds(1);
+    } else {
+        timeWindow = std::chrono::seconds(seconds);
+    }
+}
+
+bool FixedWindowRateLimitor::validate() {
+    if (this->rate < 1) {
+        return true;
+    }
+
+    TimePoint now = TimePoint::clock::now();
+    std::chrono::duration<double> span = now - this->startTime;
+
+    bool falseValue = false;
+    if (span > this->timeWindow && resetLock.compare_exchange_weak(falseValue, true)) {
+        int64_t timeSpan = static_cast<int64_t>(floor(span.count()));
+        timeSpan = timeSpan - timeSpan % this->timeWindow.count();
+
+        this->startTime += std::chrono::seconds(timeSpan);
+        this->currentCount.store(0);
+
+        resetLock.store(false);
+    }
+
+    if (++this->currentCount > this->rate && span < this->timeWindow) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -22,7 +22,7 @@
 #include "sky_rate_limit.h"
 #include "sky_log.h"
 
-FixedWindowRateLimitor::FixedWindowRateLimitor(int64_t rate, int seconds) : rate(rate), currentCount(0), resetLock(false) {
+FixedWindowRateLimiter::FixedWindowRateLimiter(int64_t rate, int seconds) : rate(rate), currentCount(0), resetLock(false) {
     if (seconds < 1) {
         timeWindow = std::chrono::seconds(1);
     } else {
@@ -32,7 +32,7 @@ FixedWindowRateLimitor::FixedWindowRateLimitor(int64_t rate, int seconds) : rate
     this->startTime = TimePoint::clock::now();
 }
 
-bool FixedWindowRateLimitor::validate() {
+bool FixedWindowRateLimiter::validate() {
     if (this->rate < 1) {
         return true;
     }
@@ -52,7 +52,7 @@ bool FixedWindowRateLimitor::validate() {
     }
 
     if (++this->currentCount > this->rate && span < this->timeWindow) {
-        sky_log("rate limitor hit: " + std::to_string(this->currentCount) + "/" + std::to_string(this->rate));
+        sky_log("rate limiter hit: " + std::to_string(this->currentCount) + "/" + std::to_string(this->rate));
         return false;
     }
 

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -33,6 +33,7 @@ bool FixedWindowRateLimitor::validate() {
     }
 
     if (++this->currentCount > this->rate && span < this->timeWindow) {
+        sky_log("rate limit hit: " + std::to_string(this->currentCount) + "/" + std::to_string(this->rate));
         return false;
     }
 

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -22,7 +22,7 @@ bool FixedWindowRateLimitor::validate() {
     std::chrono::duration<double> span = now - this->startTime;
 
     bool falseValue = false;
-    if (span > this->timeWindow && resetLock.compare_exchange_weak(falseValue, true)) {
+    if (span > this->timeWindow && resetLock.compare_exchange_weak(falseValue, true) && span > this->timeWindow) {
         int64_t timeSpan = static_cast<int64_t>(floor(span.count()));
         timeSpan = timeSpan - timeSpan % this->timeWindow.count();
 

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2021 SkyAPM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+
 #include <cmath>
 #include <cstdio>
 #include "sky_rate_limit.h"

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -33,7 +33,7 @@ bool FixedWindowRateLimitor::validate() {
     }
 
     if (++this->currentCount > this->rate && span < this->timeWindow) {
-        sky_log("rate limit hit: " + std::to_string(this->currentCount) + "/" + std::to_string(this->rate));
+        sky_log("rate limitor hit: " + std::to_string(this->currentCount) + "/" + std::to_string(this->rate));
         return false;
     }
 

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -33,9 +33,6 @@ bool FixedWindowRateLimitor::validate() {
     }
 
     if (++this->currentCount > this->rate && span < this->timeWindow) {
-        char buf[100] = { 0 };
-        snprintf(buf, sizeof(buf), "rate limitor hit: %ld/%ld in 3 seconds", this->currentCount.load(), this->rate);
-        sky_log(buf);
         return false;
     }
 

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cstdio>
 #include "sky_rate_limit.h"
 #include "sky_log.h"
 
@@ -32,7 +33,9 @@ bool FixedWindowRateLimitor::validate() {
     }
 
     if (++this->currentCount > this->rate && span < this->timeWindow) {
-        sky_log("rate limitor hit: " + std::to_string(this->currentCount) + "/" + std::to_string(this->rate) + " in 3 seconds");
+        char buf[100] = { 0 };
+        snprintf(buf, sizeof(buf), "rate limitor hit: %ld/%ld in 3 seconds", this->currentCount.load(), this->rate);
+        sky_log(buf);
         return false;
     }
 

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -7,6 +7,8 @@ FixedWindowRateLimitor::FixedWindowRateLimitor(int64_t rate, int seconds) : rate
     } else {
         timeWindow = std::chrono::seconds(seconds);
     }
+
+    this->startTime = TimePoint::clock::now();
 }
 
 bool FixedWindowRateLimitor::validate() {

--- a/src/sky_rate_limit.cc
+++ b/src/sky_rate_limit.cc
@@ -1,5 +1,6 @@
 #include <cmath>
 #include "sky_rate_limit.h"
+#include "sky_log.h"
 
 FixedWindowRateLimitor::FixedWindowRateLimitor(int64_t rate, int seconds) : rate(rate), currentCount(0), resetLock(false) {
     if (seconds < 1) {
@@ -31,6 +32,7 @@ bool FixedWindowRateLimitor::validate() {
     }
 
     if (++this->currentCount > this->rate && span < this->timeWindow) {
+        sky_log("rate limitor hit: " + std::to_string(this->currentCount) + "/" + std::to_string(this->rate) + " in 3 seconds");
         return false;
     }
 

--- a/src/sky_rate_limit.h
+++ b/src/sky_rate_limit.h
@@ -9,7 +9,7 @@ class FixedWindowRateLimitor {
 public:
     using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
 
-    FixedWindowRateLimitor(int64_t rate, int seconds = 1);
+    FixedWindowRateLimitor(int64_t rate, int seconds = 3);
     bool validate();
 
 private:

--- a/src/sky_rate_limit.h
+++ b/src/sky_rate_limit.h
@@ -1,0 +1,24 @@
+#ifndef SKYWALKING_SKY_RATE_LIMIT_H
+#define SKYWALKING_SKY_RATE_LIMIT_H
+
+#include <cstdint>
+#include <chrono>
+#include <atomic>
+
+class FixedWindowRateLimitor {
+public:
+    using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+
+    FixedWindowRateLimitor(int64_t rate, int seconds = 1);
+    bool validate();
+
+private:
+    std::atomic_int64_t currentCount;
+    int64_t rate;
+    std::chrono::duration<int> timeWindow; // second
+    TimePoint startTime;
+
+    std::atomic_bool resetLock;
+};
+
+#endif // SKYWALKING_SKY_RATE_LIMIT_H

--- a/src/sky_rate_limit.h
+++ b/src/sky_rate_limit.h
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2021 SkyAPM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
 #ifndef SKYWALKING_SKY_RATE_LIMIT_H
 #define SKYWALKING_SKY_RATE_LIMIT_H
 

--- a/src/sky_rate_limit.h
+++ b/src/sky_rate_limit.h
@@ -23,11 +23,11 @@
 #include <chrono>
 #include <atomic>
 
-class FixedWindowRateLimitor {
+class FixedWindowRateLimiter {
 public:
     using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
 
-    FixedWindowRateLimitor(int64_t rate, int seconds = 3);
+    FixedWindowRateLimiter(int64_t rate, int seconds = 3);
     bool validate();
 
 private:

--- a/src/sky_utils.cc
+++ b/src/sky_utils.cc
@@ -132,25 +132,27 @@ Segment *sky_get_segment(zend_execute_data *execute_data, int64_t request_id) {
     }
 
     auto *segments = static_cast<std::unordered_map<uint64_t, Segment *> *>SKYWALKING_G(segment);
-
+    uint64_t key = -1;
     if (request_id >= 0) {
-        try {
-            return segments->at(request_id);
-        } catch (...) {}
+        key = request_id;
     } else {
         if (SKYWALKING_G(is_swoole)) {
             int64_t fd = sky_find_swoole_fd(execute_data);
             if (fd > 0) {
-                try {
-                    return segments->at(fd);
-                } catch (...) {}
+                key = fd;
             }
         } else {
-            try {
-                return segments->at(0);
-            } catch (...) {}
+            key = 0;
         }
     }
+
+    if (key > -1) {
+        auto it = segments->find(key);
+        if (it != segments->end()) {
+            return it->second;
+        }
+    }
+
     return nullptr;
 }
 

--- a/src/sky_utils.cc
+++ b/src/sky_utils.cc
@@ -134,15 +134,21 @@ Segment *sky_get_segment(zend_execute_data *execute_data, int64_t request_id) {
     auto *segments = static_cast<std::unordered_map<uint64_t, Segment *> *>SKYWALKING_G(segment);
 
     if (request_id >= 0) {
-        return segments->at(request_id);
+        try {
+            return segments->at(request_id);
+        } catch (...) {}
     } else {
         if (SKYWALKING_G(is_swoole)) {
             int64_t fd = sky_find_swoole_fd(execute_data);
             if (fd > 0) {
-                return segments->at(fd);
+                try {
+                    return segments->at(fd);
+                } catch (...) {}
             }
         } else {
-            return segments->at(0);
+            try {
+                return segments->at(0);
+            } catch (...) {}
         }
     }
     return nullptr;

--- a/src/sky_utils.cc
+++ b/src/sky_utils.cc
@@ -132,21 +132,24 @@ Segment *sky_get_segment(zend_execute_data *execute_data, int64_t request_id) {
     }
 
     auto *segments = static_cast<std::unordered_map<uint64_t, Segment *> *>SKYWALKING_G(segment);
-    uint64_t key = -1;
+    bool do_search = false;
+    uint64_t key = 0;
     if (request_id >= 0) {
         key = request_id;
+        do_search = true;
     } else {
         if (SKYWALKING_G(is_swoole)) {
             int64_t fd = sky_find_swoole_fd(execute_data);
             if (fd > 0) {
                 key = fd;
+                do_search = true;
             }
         } else {
-            key = 0;
+            do_search = true;
         }
     }
 
-    if (key > -1) {
+    if (do_search) {
         auto it = segments->find(key);
         if (it != segments->end()) {
             return it->second;

--- a/src/sky_utils.h
+++ b/src/sky_utils.h
@@ -38,6 +38,10 @@ int64_t sky_find_swoole_fd(zend_execute_data *execute_data);
 
 Segment *sky_get_segment(zend_execute_data *execute_data, int64_t request_id);
 
+bool sky_insert_segment(uint64_t request_id, Segment *segment);
+
+void sky_remove_segment(uint64_t request_id);
+
 std::string sky_get_class_name(zval *obj);
 
 long getUnixTimeStamp();

--- a/src/span.cc
+++ b/src/span.cc
@@ -29,10 +29,23 @@ Span::Span() {
 }
 
 Span::~Span() {
+    for (Tag *tag : tags) {
+        delete tag;
+    }
     tags.clear();
     tags.shrink_to_fit();
+
+    for (SkyCoreSpanLog *log : logs) {
+        delete log;
+    }
     logs.clear();
     logs.shrink_to_fit();
+
+    for (SkySegmentReference *ref : refs) {
+        delete ref;
+    }
+    refs.clear();
+    refs.shrink_to_fit();
 }
 
 // get
@@ -52,15 +65,15 @@ long Span::getEndTime() const {
     return endTime;
 }
 
-std::vector<SkySegmentReference *> Span::getRefs() {
+const std::vector<SkySegmentReference *> &Span::getRefs() {
     return refs;
 }
 
-std::string Span::getOperationName() {
+const std::string &Span::getOperationName() {
     return operationName;
 }
 
-std::string Span::getPeer() {
+const std::string &Span::getPeer() {
     return peer;
 }
 
@@ -80,11 +93,11 @@ bool Span::getIsError() const {
     return isError;
 }
 
-std::vector<Tag *> Span::getTags() {
+const std::vector<Tag *> &Span::getTags() {
     return tags;
 }
 
-std::vector<SkyCoreSpanLog *> Span::getLogs() {
+const std::vector<SkyCoreSpanLog *> &Span::getLogs() {
     return logs;
 }
 

--- a/src/span.cc
+++ b/src/span.cc
@@ -65,15 +65,15 @@ long Span::getEndTime() const {
     return endTime;
 }
 
-const std::vector<SkySegmentReference *> &Span::getRefs() {
+const std::vector<SkySegmentReference*>& Span::getRefs() {
     return refs;
 }
 
-const std::string &Span::getOperationName() {
+const std::string& Span::getOperationName() {
     return operationName;
 }
 
-const std::string &Span::getPeer() {
+const std::string& Span::getPeer() {
     return peer;
 }
 
@@ -93,11 +93,11 @@ bool Span::getIsError() const {
     return isError;
 }
 
-const std::vector<Tag *> &Span::getTags() {
+const std::vector<Tag*>& Span::getTags() {
     return tags;
 }
 
-const std::vector<SkyCoreSpanLog *> &Span::getLogs() {
+const std::vector<SkyCoreSpanLog*>& Span::getLogs() {
     return logs;
 }
 

--- a/src/span.h
+++ b/src/span.h
@@ -52,11 +52,11 @@ public:
 
     long getEndTime() const;
 
-    std::vector<SkySegmentReference *> &getRefs();
+    const std::vector<SkySegmentReference *>& getRefs();
 
-    std::string getOperationName();
+    const std::string& getOperationName();
 
-    std::string getPeer();
+    const std::string& getPeer();
 
     SkySpanType getSpanType();
 
@@ -66,9 +66,9 @@ public:
 
     bool getIsError() const;
 
-    std::vector<Tag *> &getTags();
+    const std::vector<Tag *>& getTags();
 
-    std::vector<SkyCoreSpanLog *> &getLogs();
+    const std::vector<SkyCoreSpanLog*>& getLogs();
 
     bool getSkipAnalysis() const;
 

--- a/src/span.h
+++ b/src/span.h
@@ -52,7 +52,7 @@ public:
 
     long getEndTime() const;
 
-    std::vector<SkySegmentReference *> getRefs();
+    std::vector<SkySegmentReference *> &getRefs();
 
     std::string getOperationName();
 
@@ -66,9 +66,9 @@ public:
 
     bool getIsError() const;
 
-    std::vector<Tag *> getTags();
+    std::vector<Tag *> &getTags();
 
-    std::vector<SkyCoreSpanLog *> getLogs();
+    std::vector<SkyCoreSpanLog *> &getLogs();
 
     bool getSkipAnalysis() const;
 

--- a/src/tag.cc
+++ b/src/tag.cc
@@ -24,10 +24,10 @@ Tag::Tag(std::string key, std::string value) : _key(std::move(key)), _value(std:
     _value.erase(_value.find_last_not_of(' ') + 1);
 }
 
-const std::string &Tag::getKey() {
+const std::string& Tag::getKey() {
     return _key;
 }
 
-const std::string &Tag::getValue() {
+const std::string& Tag::getValue() {
     return _value;
 }

--- a/src/tag.cc
+++ b/src/tag.cc
@@ -24,10 +24,10 @@ Tag::Tag(std::string key, std::string value) : _key(std::move(key)), _value(std:
     _value.erase(_value.find_last_not_of(' ') + 1);
 }
 
-std::string Tag::getKey() {
+const std::string &Tag::getKey() {
     return _key;
 }
 
-std::string Tag::getValue() {
+const std::string &Tag::getValue() {
     return _value;
 }

--- a/src/tag.h
+++ b/src/tag.h
@@ -25,9 +25,9 @@ class Tag {
 public:
     Tag(std::string key, std::string value);
 
-    std::string &getKey();
+    const std::string& getKey();
     
-    std::string &getValue();
+    const std::string& getValue();
 
 private:
     std::string _key;

--- a/src/tag.h
+++ b/src/tag.h
@@ -25,9 +25,9 @@ class Tag {
 public:
     Tag(std::string key, std::string value);
 
-    std::string getKey();
+    std::string &getKey();
     
-    std::string getValue();
+    std::string &getValue();
 
 private:
     std::string _key;


### PR DESCRIPTION
- 修复内存泄漏
- 使用 unordered_map 替换 map， unordered_map 具有更好的性能
- 成员函数返回string，都采用const引用方式
- 支持rate_limit (共享内存方式性能太差，采用一个进程一个限速器的方式。举例：如果php-fpm进程数是100，那么限速 100QPS的设置为：skywalking.sample_n_per_3_secs=3， 小于1为不限速)
- 支持固定实例名称 （skywalking.instance_name="my_instance",  空串将使用原来的uuid方式）