### PR TITLE
修复swoft长时间运行sigbus错误

### DIFF
--- a/php_skywalking.h
+++ b/php_skywalking.h
@@ -150,6 +150,10 @@ ZEND_BEGIN_MODULE_GLOBALS(skywalking)
 
     // fixed UUID
     char *instance_name;
+
+    // queue name unique
+    zend_bool mq_unique;
+
 ZEND_END_MODULE_GLOBALS(skywalking)
 
 extern ZEND_DECLARE_MODULE_GLOBALS(skywalking);

--- a/skywalking.cc
+++ b/skywalking.cc
@@ -65,10 +65,13 @@ PHP_INI_BEGIN()
     STD_PHP_INI_BOOLEAN("skywalking.error_handler_enable", "0", PHP_INI_ALL, OnUpdateBool, error_handler_enable, zend_skywalking_globals, skywalking_globals)
 
     STD_PHP_INI_ENTRY("skywalking.mq_max_message_length", "20480", PHP_INI_ALL, OnUpdateLong, mq_max_message_length, zend_skywalking_globals, skywalking_globals)
+    STD_PHP_INI_ENTRY("skywalking.mq_unique", "0", PHP_INI_ALL, OnUpdateBool, mq_unique, zend_skywalking_globals, skywalking_globals)
 
     STD_PHP_INI_ENTRY("skywalking.sample_n_per_3_secs", "-1", PHP_INI_ALL, OnUpdateLong, sample_n_per_3_secs, zend_skywalking_globals, skywalking_globals)
 
     STD_PHP_INI_ENTRY("skywalking.instance_name", "", PHP_INI_ALL, OnUpdateString, instance_name, zend_skywalking_globals, skywalking_globals)
+
+
 
 PHP_INI_END()
 

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -81,7 +81,11 @@ void sky_module_init() {
     FixedWindowRateLimiter *rate_limiter = new FixedWindowRateLimiter(SKYWALKING_G(sample_n_per_3_secs));
     SKYWALKING_G(rate_limiter) = rate_limiter;
 
-    sprintf(s_info->mq_name, "skywalking_queue_%d", getpid());
+    if (SKYWALKING_G(mq_unique)) {
+        sprintf(s_info->mq_name, "skywalking_queue");
+    }else{
+        sprintf(s_info->mq_name, "skywalking_queue_%d", getpid());
+    }
 
     try {
         boost::interprocess::message_queue::remove(s_info->mq_name);
@@ -112,7 +116,13 @@ void sky_module_init() {
 
 void sky_module_cleanup() {
     char mq_name[32];
-    sprintf(mq_name, "skywalking_queue_%d", getpid());
+
+    if (SKYWALKING_G(mq_unique)) {
+        sprintf(mq_name, "skywalking_queue");
+    }else{
+        sprintf(mq_name, "skywalking_queue_%d", getpid());
+    }
+//    sprintf(mq_name, "skywalking_queue_%d", getpid());
     if (strcmp(s_info->mq_name, mq_name) == 0) {
         boost::interprocess::message_queue::remove(s_info->mq_name);
     }

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -117,13 +117,8 @@ void sky_module_init() {
 void sky_module_cleanup() {
     char mq_name[32];
 
-    if (SKYWALKING_G(mq_unique)) {
-        sprintf(mq_name, "skywalking_queue");
-    }else{
-        sprintf(mq_name, "skywalking_queue_%d", getpid());
-    }
-//    sprintf(mq_name, "skywalking_queue_%d", getpid());
-    if (strcmp(s_info->mq_name, mq_name) == 0) {
+    sprintf(mq_name, "skywalking_queue_%d", getpid());
+    if (SKYWALKING_G(mq_unique) || strcmp(s_info->mq_name, mq_name) == 0) {
         boost::interprocess::message_queue::remove(s_info->mq_name);
     }
 


### PR DESCRIPTION
增加消息队列唯一名称配置,避免swoft长时间运行sigbus错误
