### PR TITLE
增加laravel-swoole支持

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -64,14 +64,14 @@ To build gRPC from source, you may need to install the following packages from H
 
 ## Build from source with static gRPC library (PHP Extension)
 
-Use the `--with-grpc-src` option to set the path of the gRPC static library
+Use the `--with-grpc` option to set the path of the gRPC static library
 
 ```shell script
 curl -Lo v4.2.0.tar.gz https://github.com/SkyAPM/SkyAPM-php-sdk/archive/v4.2.0.tar.gz
 tar zxvf v4.2.0.tar.gz
 cd SkyAPM-php-sdk-4.2.0
 phpize
-./configure --with-grpc-src="/var/local/git/grpc"
+./configure --with-grpc="/var/local/git/grpc"
 make
 sudo make install
 ```

--- a/php_skywalking.h
+++ b/php_skywalking.h
@@ -77,7 +77,8 @@ extern zend_module_entry skywalking_module_entry;
 #define SKY_IS_SWOFT(class_name, func_name) (SKY_STRCMP(class_name, "Swoft\\Http\\Server\\Swoole\\RequestListener") && SKY_STRCMP(func_name, "onRequest"))
 #define SKY_IS_TARS(class_name, func_name) (SKY_STRCMP(class_name, "Tars\\core\\Server") && SKY_STRCMP(func_name, "onRequest"))
 #define SKY_IS_LARAVELS(class_name, func_name) ((SKY_STRCMP(class_name, "Hhxsv\\LaravelS\\LaravelS") || SKY_STRCMP(class_name, "Hhxsv5\\LaravelS\\LaravelS")) && SKY_STRCMP(func_name, "onRequest"))
-#define SKY_IS_SWOOLE_FRAMEWORK(class_name, func_name) SKY_IS_HYPERF(class_name, func_name) || SKY_IS_SWOFT(class_name, func_name) || SKY_IS_TARS(class_name, func_name) || SKY_IS_LARAVELS(class_name, func_name)
+#define SKY_IS_LARAVEL_SWOOLE(class_name, func_name) (SKY_STRCMP(class_name, "SwooleTW\\Http\\Server\\Manager") && SKY_STRCMP(func_name, "onRequest"))
+#define SKY_IS_SWOOLE_FRAMEWORK(class_name, func_name) SKY_IS_HYPERF(class_name, func_name) || SKY_IS_SWOFT(class_name, func_name) || SKY_IS_TARS(class_name, func_name) || SKY_IS_LARAVELS(class_name, func_name) || SKY_IS_LARAVEL_SWOOLE(class_name, func_name)
 
 #if PHP_VERSION_ID < 80000
 #define SKY_ZEND_CALL_METHOD(obj, fn, func, ret, param, arg1, arg2) zend_call_method(obj, Z_OBJCE_P(obj), fn, ZEND_STRL(func), ret, param, arg1, arg2);


### PR DESCRIPTION
laravel-swoole 是一款类似 laravel-s 的针对 Laravel/Lumen 提供 swoole 能力的扩展库。

仓库见：https://github.com/swooletw/laravel-swoole