### PR TITLE
修复空指针导致进程产生core dump

### DIFF
--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -221,7 +221,7 @@ void sky_request_flush(zval *response, uint64_t request_id) {
     if (segment->skip()) {
         delete segment;
         sky_remove_segment(request_id);
-
+        
         return;
     }
 

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -55,7 +55,7 @@ void sky_module_init() {
     if (SKYWALKING_G(error_handler_enable)) {
         sky_plugin_error_init();
     }
-
+    
     // bind curl
     zend_function *old_function;
     if ((old_function = SKY_OLD_FN("curl_exec")) != nullptr) {
@@ -221,7 +221,7 @@ void sky_request_flush(zval *response, uint64_t request_id) {
     if (segment->skip()) {
         delete segment;
         sky_remove_segment(request_id);
-        
+
         return;
     }
 

--- a/src/sky_module.cc
+++ b/src/sky_module.cc
@@ -55,7 +55,7 @@ void sky_module_init() {
     if (SKYWALKING_G(error_handler_enable)) {
         sky_plugin_error_init();
     }
-    
+
     // bind curl
     zend_function *old_function;
     if ((old_function = SKY_OLD_FN("curl_exec")) != nullptr) {
@@ -215,6 +215,9 @@ void sky_request_init(zval *request, uint64_t request_id) {
 
 void sky_request_flush(zval *response, uint64_t request_id) {
     auto *segment = sky_get_segment(nullptr, request_id);
+    if (nullptr == segment) {
+        return;
+    }
     if (segment->skip()) {
         delete segment;
         sky_remove_segment(request_id);


### PR DESCRIPTION
4.2.0版本，在本地编译安装后，在php-fpm日志发现每个请求进来后都没能返回完整的响应，查日志发现 core dump 。

    [13-Feb-2022 17:17:10.329551] DEBUG: pid 1024955, fpm_got_signal(), line 82: received SIGCHLD
    [13-Feb-2022 17:17:10.329577] DEBUG: pid 1024955, fpm_event_loop(), line 430: event module triggered 1 events
    [13-Feb-2022 17:17:10.329602] WARNING: pid 1024955, fpm_children_bury(), line 259: [pool fpms4] child 1024964 exited on signal 11 (SIGSEGV - core dumped) after 50.634819 seconds from start
    [13-Feb-2022 17:17:10.329608] DEBUG: pid 1024955, fpm_children_make(), line 407: blocking signals before child birth
    [13-Feb-2022 17:17:10.329886] DEBUG: pid 1024955, fpm_children_make(), line 431: unblocking signals, child born
    [13-Feb-2022 17:17:10.329929] NOTICE: pid 1024955, fpm_children_make(), line 437: [pool fpms4] child 1025215 started

用GDB调试打开 core dump 文件发现：

    (gdb) bt
    #0  0x00007f1ec3ee97f8 in Segment::skip() ()
       from /opt/php7.4.16/lib/php/extensions/no-debug-non-zts-20190902/skywalking.so
    #1  0x00007f1ec3ef0292 in sky_request_flush(_zval_struct*, unsigned long) ()
       from /opt/php7.4.16/lib/php/extensions/no-debug-non-zts-20190902/skywalking.so
    #2  0x00007f1ec3ea6402 in zm_deactivate_skywalking ()
       from /opt/php7.4.16/lib/php/extensions/no-debug-non-zts-20190902/skywalking.so
    #3  0x000055c3a9743c41 in zend_deactivate_modules ()
    #4  0x000055c3a966c0d7 in php_request_shutdown ()
    #5  0x000055c3a98f7281 in main ()
    (gdb) 

调试代码，发现是空指针：

```C++
// 函数 sky_request_flush：
auto *segment = sky_get_segment(nullptr, request_id);
if (segment->skip()) {
    delete segment;
    sky_remove_segment(request_id);
    
    return;
}
```

我加了个判断，如果 `segment` 是空指针的话就直接返回了。
