### PR TITLE
Fix `skywalking.grpc_address` in Docker entrypoint not set properly.

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,6 +19,7 @@ grpc=$SW_OAP_ADDRESS
 
 if [ ! $grpc ]; then
     grpc="127.0.0.1:11800"
+else
     sed -i "s/127.0.0.1:11800/$grpc/g" $PHP_INI_DIR/conf.d/ext-skywalking.ini
 fi
 


### PR DESCRIPTION
Tested within a container on Kubernetes, setting the `SW_OAP_ADDRESS` environment variable does not change it in the skywalking extension's `php.ini` file. 
(`skyapm/skywalking-php:v5.0.1-7.3-fpm-alpine` was used)

```
bash-5.1# php -i | grep skywalking
System => Linux skywalking-test-php-apm-xxxxxxxxxx-xxxxx - #90~18.04.1-Ubuntu SMP Fri Jun 10 18:32:22 UTC 2022 x86_64
/usr/local/etc/php/conf.d/ext-skywalking.ini
skywalking
skywalking.curl_response_enable => On => On
skywalking.enable => On => On
skywalking.error_handler_enable => Off => Off
skywalking.grpc_address => 127.0.0.1:11800 => 127.0.0.1:11800
skywalking.grpc_tls_enable => Off => Off
skywalking.grpc_tls_pem_cert_chain => no value => no value
skywalking.grpc_tls_pem_private_key => no value => no value
skywalking.grpc_tls_pem_root_certs => no value => no value
skywalking.log_level => debug => debug
skywalking.log_path => /tmp/skywalking-php.log => /tmp/skywalking-php.log
skywalking.mq_max_message_length => 20480 => 20480
skywalking.mq_unique => 0 => 0
skywalking.oap_authentication => no value => no value
skywalking.oap_cross_process_protocol => 3.0 => 3.0
skywalking.oap_version => 9.0.0 => 9.0.0
skywalking.sample_n_per_3_secs => -1 => -1
skywalking.service => skywalking => skywalking
skywalking.service_instance => no value => no value
HOSTNAME => skywalking-test-php-apm-xxxxxxxxxx-xxxxx
SW_OAP_ADDRESS => skywalking-aop-svc:11800
$_SERVER['HOSTNAME'] => skywalking-test-php-apm-xxxxxxxxxx-xxxxx
$_SERVER['SW_OAP_ADDRESS'] => skywalking-aop-svc:11800
$_ENV['HOSTNAME'] => skywalking-test-php-apm-xxxxxxxxxx-xxxxx
$_ENV['SW_OAP_ADDRESS'] => skywalking-aop-svc:11800
```
