### PR TITLE
fix grpc bug, deadlock and Bad metadata value given

### DIFF
--- a/src/sky_execute.cc
+++ b/src/sky_execute.cc
@@ -89,8 +89,8 @@ void sky_execute_ex(zend_execute_data *execute_data) {
         if (strcmp(function_name, "executeCommand") == 0) {
             span = sky_predis(execute_data, class_name, function_name);
         } else if (strcmp(class_name, "Grpc\\BaseStub") == 0) {
-            afterExec = false;
             span = sky_plugin_grpc(execute_data, class_name, function_name);
+            afterExec = span == nullptr;
         } else if (strcmp(class_name, "PhpAmqpLib\\Channel\\AMQPChannel") == 0) {
             span = sky_plugin_rabbit_mq(execute_data, class_name, function_name);
         } else if ((SKY_STRCMP(class_name, "Hyperf\\Guzzle\\CoroutineHandler") ||

--- a/src/sky_plugin_grpc.cc
+++ b/src/sky_plugin_grpc.cc
@@ -66,19 +66,32 @@ SkyCoreSpan *sky_plugin_grpc(zend_execute_data *execute_data, char *class_name, 
         }
 
         std::string sw_header = segment->createHeader(span);
+        zval *sw8_val;
+#if PHP_MAJOR_VERSION < 7
+        MAKE_STD_ZVAL(sw8_val);
+        array_init(sw8_val);
+        add_next_index_stringl(sw8_val, sw_header.c_str(), sw_header.length(), 1);
+#else
+        sw8_val = (zval *)emalloc(sizeof(zval));
+        array_init(sw8_val);
+        add_next_index_stringl(sw8_val, sw_header.c_str(), sw_header.length());
+#endif
         if (nullptr != metadata) {
             if (Z_TYPE_P(metadata) == IS_UNDEF) {
                 array_init(metadata);
-                add_assoc_str(metadata, "sw8", zend_string_init(sw_header.c_str(), sw_header.length(), 0));
+                add_assoc_zval(metadata, "sw8", sw8_val);
                 ZVAL_ARR(ZEND_CALL_ARG(execute_data, offset), Z_ARR_P(metadata));
                 execute_data->This.u2.num_args = offset;
             } else if (Z_TYPE_P(metadata) == IS_ARRAY) {
                 SEPARATE_ARRAY(metadata);
-                add_assoc_str(metadata, "sw8", zend_string_init(sw_header.c_str(), sw_header.length(), 0));
+                add_assoc_zval(metadata, "sw8", sw8_val);
             }
         }
 
         ori_execute_ex(execute_data);
+#if PHP_MAJOR_VERSION >= 7
+        efree(sw8_val);
+#endif     
         span->setEndTIme();
         return span;
     }


### PR DESCRIPTION
1.  grpc 调用时卡死，如果调用的方法不是拦截的方法会导致不调用`ori_execute_ex`
2.  grpc 调用时报错`Bad metadata value given`,  metadata 设置sw8格式错误， sw8值必须为数组 [https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/call.c#L134](url)